### PR TITLE
Have the CI workflow only run on review requested and not on PR creation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, reopened, review_requested, ready_for_review]
+    types: [review_requested]
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
Saves some actions minutes. For smaller PRs this action would have ran twice which would be overkill. For larger PRs it will run as many times as a review is requested.